### PR TITLE
Better support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,18 @@
-# Donot use this Dockerfile.This is not ready yet.
+FROM golang:1.6.3
 
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang
+ENV STATUSOK_VERSION 0.1.1
 
-# Copy the local package files to the container's workspace.
-ADD . /go/src/github.com/sanathp/StatusOk
+RUN apt-get update \
+    && apt-get install -y unzip \
+    && wget https://github.com/sanathp/statusok/releases/download/$STATUSOK_VERSION/statusok_linux.zip \
+    && unzip statusok_linux.zip \
+    && mv ./statusok_linux/statusok /go/bin/StatusOk \
+    && rm -rf ./statusok_linux* \
+    && apt-get remove -y unzip git \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Build the outyet command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
-RUN go get github.com/codegangsta/cli
-RUN go get github.com/influxdb/influxdb
-RUN go get github.com/mailgun/mailgun-go
-RUN go install github.com/sanathp/StatusOk
-
-RUN wget http://influxdb.s3.amazonaws.com/influxdb_0.9.3_amd64.deb
-RUN dpkg -i influxdb_0.9.3_amd64.deb
-RUN /etc/init.d/influxdb start
-
-RUN wget https://grafanarel.s3.amazonaws.com/builds/grafana_2.1.3_amd64.deb
-RUN apt-get update
-RUN apt-get install -y adduser libfontconfig
-RUN dpkg -i grafana_2.1.3_amd64.deb
-RUN service grafana-server start
-
-#how to connect to localhost inside ?? http://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach
-
-ENTRYPOINT /go/bin/StatusOk --config /go/src/github.com/sanathp/StatusOk/config.json
-
-# Document that the service listens 
-EXPOSE 80 8083 8086 7321 3000
+VOLUME /config
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT /docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -129,6 +129,46 @@ Notifications will be triggered when mean response time is below given response 
 
 Adding support to other clients is simple.[view details](https://github.com/sanathp/statusok/blob/master/Config.md#write-your-own-notification-client)
 
+## Running with plain Docker
+
+```
+docker run -d -v /path/to/config/folder:/config sanathp/statusok
+```
+
+*Note*: Config folder should contain config file with name `config.json`
+
+## Running with Docker Compose
+
+Prepare docker-compose.yml config like this:
+
+```
+version: '2'
+services:
+  statusok:
+    build: sanathp/statusok
+    volumes:
+      - /path/to/config/folder:/config
+    depends_on:
+      - influxdb
+  influxdb:
+    image: tutum/influxdb:0.9
+    environment:
+      - PRE_CREATE_DB="statusok" 
+    ports:
+      - 8083:8083 
+      - 8086:8086
+  grafana:
+    image: grafana/grafana
+    ports:
+      - 3000:3000
+```
+
+Now run it:
+
+```
+docker-compose up
+```
+
 ## Contribution
 
 Contributions are welcomed and greatly appreciated. Create an issue if you find bugs.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+sleep 5 # Workaround to wait untill InfluxDb will start
+/go/bin/StatusOk --config /config/config.json


### PR DESCRIPTION
- image is now ready to be uploaded to Docker Hub;
- InfluxDb and Grafana removed to follow Docker best practices. See
  https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run-only-one-process-per-container
  for more info;
- README updated with docker and docker-compose examples;
