### PR TITLE
Dingding initialization bug fix

### DIFF
--- a/notify/dingding_notify.go
+++ b/notify/dingding_notify.go
@@ -10,7 +10,9 @@ import (
 )
 
 type DingdingNotify struct {
-	HttpNotify
+	Url         string            `json:"url"`
+	RequestType string            `json:"requestType"`
+	Headers     map[string]string `json:"headers"`
 }
 
 type Txt struct {


### PR DESCRIPTION
The dingding service was being initialized even if it wasn't set in the config file.  It looks like the issue was tied to the data structure being incorrect when trying to decode the JSON file.