### PR TITLE
Add the ability to look in the environment for PORT

### DIFF
--- a/statusok.go
+++ b/statusok.go
@@ -113,7 +113,10 @@ func startMonitoring(configFileName string, logFileName string) {
 	//Just to check StatusOk is running or not
 	http.HandleFunc("/", statusHandler)
 
-	if config.Port == 0 {
+	port, portSet := os.LookupEnv("PORT")
+	if portSet == true {
+		http.ListenAndServe(":"+port, nil)
+	} else if config.Port == 0 {
 		//Default port
 		http.ListenAndServe(":7321", nil)
 	} else {


### PR DESCRIPTION
This makes statusOk work with PaaSes like Cloud Foundry,
who require you to listen on a specific port that they set
via an environment variable.