### PR TITLE
Change series name to "statusok.request" and store URL as a tag instead

### DIFF
--- a/database/influxdb.go
+++ b/database/influxdb.go
@@ -83,6 +83,7 @@ func (influxDb InfluxDb) AddRequestInfo(requestInfo RequestInfo) error {
 	tags := map[string]string{
 		"requestId":   strconv.Itoa(requestInfo.Id),
 		"requestType": requestInfo.RequestType,
+		"url": requestInfo.Url,
 	}
 	fields := map[string]interface{}{
 		"responseTime": requestInfo.ResponseTime,
@@ -99,7 +100,7 @@ func (influxDb InfluxDb) AddRequestInfo(requestInfo RequestInfo) error {
 	}
 
 	point, err := client.NewPoint(
-		requestInfo.Url,
+		"statusok.request",
 		tags,
 		fields,
 		time.Now(),


### PR DESCRIPTION
The way data is pushed into influxdb right now is somewhat unorthodox and difficult to work with due to the URL being used as the series name. This means that adding any new URL to the config adds new series instead of extending the existing corpus of data.

TL;DR; a much more traditional way of structuring data in InfluxDB is to have a single series that I chose to call "statusok.request" and store the URL as a tag of each datapoint. This way the data is much easier to work with, for example in Grafana.

I can't actually build and test if this works since the project is a mess, all the dependencies have changed and nothing was pinned to versions that still worked. BUT, the change is simple enough that it ought to work if the project ever becomes buildable again.